### PR TITLE
Update az-automation-accounts-privesc.md

### DIFF
--- a/src/pentesting-cloud/azure-security/az-privilege-escalation/az-automation-accounts-privesc.md
+++ b/src/pentesting-cloud/azure-security/az-privilege-escalation/az-automation-accounts-privesc.md
@@ -156,26 +156,13 @@ az rest --method PUT \
 
 With the permission **`Microsoft.Automation/automationAccounts/webhooks/write`** it's possible to create a new Webhook for a Runbook inside an Automation Account using the following command.
 
-Note that you will need to **indicate webhook URI** with the token to use.
+```bash
+New-AzAutomationWebHook -Name <webhook-name> -ResourceGroupName <res-group> -AutomationAccountName <automation-account-name> -RunbookName <runbook-name> -IsEnabled $true
+```
+
+This command should return a webhook URI which is only displayed on creation. Then, to call the runbook using the webhook URI
 
 ```bash
-az rest --method PUT \
---url "https://management.azure.com/subscriptions/<subscription-id>/resourceGroups/<res-group>/providers/Microsoft.Automation/automationAccounts/<automantion-account-name>/webhooks/<webhook-name>?api-version=2018-06-30" \
---body '{
-  "name": "<webhook-name>",
-  "properties": {
-    "isEnabled": true,
-    "expiryTime": "2026-01-09T20:03:30.291Z",
-    "parameters": {},
-    "runOn": null,
-    "runbook": {
-      "name": "<runbook-name>"
-    },
-    "uri": "https://f931b47b-18c8-45a2-9d6d-0211545d8c02.webhook.eus.azure-automation.net/webhooks?token=Ts5WmbKk0zcuA8PEUD4pr%2f6SM0NWydiCDqCqS1IdzIU%3d"
-  }
-}'
-
-# Then, to call the runbook using the webhook
 curl -X POST "https://f931b47b-18c8-45a2-9d6d-0211545d8c02.webhook.eus.azure-automation.net/webhooks?token=Ts5WmbKk0zcuA8PEUD4pr%2f6SM0NWydiCDqCqS1IdzIU%3d" \
   -H "Content-Length: 0"
 ```


### PR DESCRIPTION
Proposing this change in the `Microsoft.Automation/automationAccounts/webhooks/write` under the `Az - Azure Automation Accounts Privesc`. 

The command shown seems to have been taken directly from a request done through the Azure Portal. The issue is that in the Portal, the webhook URI is automatically generated, shown to the user and then sent as part of the payload for the creation of the webhook. When creating a webhook through CLI, there is no way to pre-generate the webhook URI in order to submit it for the webhook creation. 

This change uses the `New-AzAutomationWebHook` cmdlet in Powershell which takes care of the webhook URI and displays it to the user after the webhook creation
